### PR TITLE
🚨 Hotfix : Google Analytics 데이터 수집되지 않는 이슈

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import './globals.css';
 
+import Script from 'next/script';
 import { Suspense } from 'react';
 
-import { Analytics } from '@/components/Analytics';
 import { OverlayProvider } from '@/components/Overlay/OverlayProvider';
+import { GA_ID } from '@/constants/env';
 import METADATA from '@/constants/meta';
 import QueryProvider from '@/provider/QueryProvider';
 import RecoilProvider from '@/provider/RecoilProvider';
@@ -15,11 +16,24 @@ export const metadata: Metadata = METADATA;
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
+      <head>
+        {/* Google Analytics */}
+        <Script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+          strategy="afterInteractive" // after page is interactive
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_ID}');
+          `}
+        </Script>
+      </head>
       <body className="flex w-screen touch-none justify-center bg-slate-100">
         <div className="w-full max-w-440 overflow-scroll bg-white text-primary">
-          <Suspense>
-            <Analytics />
-          </Suspense>
           <QueryProvider>
             <RecoilProvider>
               <OverlayProvider>{children}</OverlayProvider>

--- a/src/components/Analytics/Analytics.tsx
+++ b/src/components/Analytics/Analytics.tsx
@@ -4,7 +4,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import Script from 'next/script';
 import { useEffect } from 'react';
 
-import { GA_ID, HOTJAR } from '@/constants/env';
+import { GA_ID } from '@/constants/env';
 import { pageview } from '@/utils/gtm';
 
 export default function Analytics() {
@@ -41,22 +41,6 @@ export default function Analytics() {
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer', '${GA_ID}');
-  `,
-        }}
-      />
-      <Script
-        id="hotjar-script"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-          (function(h,o,t,j,a,r){
-            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-            h._hjSettings={hjid:${HOTJAR.HJID},hjsv:${HOTJAR.HJSV}};
-            a=o.getElementsByTagName('head')[0];
-            r=o.createElement('script');r.async=1;
-            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-            a.appendChild(r);
-        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');;
   `,
         }}
       />


### PR DESCRIPTION
## What is this PR? :mag:
- 24년 6월 5일 이후 웹사이트 GA 데이터 수집이 안되고 있음
- 특이사항 : 프론트에서 그 시기 전후로 배포를 진행(코드에 변경사항이 생긴일)한건 6/12와 5/8 뿐 
- 정상적으로 ga 가 작동하는 다른 사이트를 확인한 결과 소스코드가 조금 다름
- 타사이트 : src="https://www.googletagmanager.com/gtag/js?id=G-"
- 포즈피커 : src="https://www.googletagmanager.com/gtm.js?id=G-"

## Changes :memo:
- 기존 Anayltics 컴포넌트 삭제 (Hotjar도 불필요하므로 함께 삭제)
- GA-4 적용을 위해 스크립트를 layout.tsx <head> 태그 내에 추가

## Screenshot :camera:
<img width="927" alt="2024-08-18_5 30 18" src="https://github.com/user-attachments/assets/a566937b-d4b9-468a-9e96-aca2a8161df9">
